### PR TITLE
Support for the multiple Email Clients

### DIFF
--- a/colossus/apps/campaigns/api.py
+++ b/colossus/apps/campaigns/api.py
@@ -2,16 +2,15 @@ import logging
 import re
 from smtplib import SMTPException
 
+import html2text
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.mail import EmailMultiAlternatives, get_connection
+from django.core.mail import EmailMultiAlternatives
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
-import html2text
-
 from colossus.apps.campaigns.constants import CampaignStatus
 from colossus.apps.subscribers.constants import ActivityTypes
-from colossus.utils import get_absolute_url
+from colossus.utils import get_absolute_url, get_campaign_connection
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +99,7 @@ def send_campaign_email_subscriber(email, subscriber, site, connection=None):
     return send_campaign_email(email, context, subscriber.get_email(), connection)
 
 
-def send_campaign_email_test(email, recipient_list):
+def send_campaign_email_test(email, recipient_list, connection=None):
     if email.campaign.mailing_list is not None:
         unsubscribe_absolute_url = get_absolute_url('subscribers:unsubscribe_manual', kwargs={
             'mailing_list_uuid': email.campaign.mailing_list.uuid
@@ -108,10 +107,12 @@ def send_campaign_email_test(email, recipient_list):
     else:
         unsubscribe_absolute_url = '#'
     context = get_test_email_context(unsub=unsubscribe_absolute_url)
-    return send_campaign_email(email, context, recipient_list, is_test=True)
+    return send_campaign_email(email, context, recipient_list, is_test=True, connection=connection)
 
 
 def send_campaign(campaign):
+    connection = get_campaign_connection(campaign=campaign)
+
     campaign.status = CampaignStatus.DELIVERING
     campaign.save(update_fields=['status'])
     site = get_current_site(request=None)  # get site based on SITE_ID
@@ -122,7 +123,7 @@ def send_campaign(campaign):
     if campaign.track_opens:
         campaign.email.enable_open_tracking()
 
-    with get_connection() as connection:
+    with connection:
         for subscriber in campaign.get_recipients():
             if not subscriber.activities.filter(activity_type=ActivityTypes.SENT, email=campaign.email).exists():
                 sent = send_campaign_email_subscriber(campaign.email, subscriber, site, connection)

--- a/colossus/apps/campaigns/forms.py
+++ b/colossus/apps/campaigns/forms.py
@@ -115,9 +115,9 @@ class CampaignTestEmailForm(forms.Form):
     class Meta:
         fields = ('email',)
 
-    def send(self, email):
+    def send(self, email, connection=None):
         recipient_email = self.cleaned_data.get('email')
-        send_campaign_email_test(email, recipient_email)
+        send_campaign_email_test(email, recipient_email, connection=connection)
 
 
 class EmailEditorForm(forms.Form):

--- a/colossus/apps/campaigns/views.py
+++ b/colossus/apps/campaigns/views.py
@@ -20,7 +20,6 @@ from colossus.apps.core.models import Country
 from colossus.apps.lists.models import MailingList
 from colossus.apps.subscribers.constants import ActivityTypes
 from colossus.apps.subscribers.models import Activity
-
 from .api import get_test_email_context
 from .constants import CampaignStatus, CampaignTypes
 from .forms import (
@@ -29,6 +28,7 @@ from .forms import (
 )
 from .mixins import CampaignMixin
 from .models import Campaign, Email, Link
+from ...utils import get_campaign_connection
 
 
 @method_decorator(login_required, name='dispatch')
@@ -173,16 +173,18 @@ class CampaignReportsView(CampaignMixin, DetailView):
             .count()
 
         subscriber_open_activities = Activity.objects \
-            .filter(email__campaign_id=self.kwargs.get('pk'), activity_type=ActivityTypes.OPENED) \
-            .values('subscriber__id', 'subscriber__email') \
-            .annotate(total_opens=Count('id')) \
-            .order_by('-total_opens')[:10]
+                                         .filter(email__campaign_id=self.kwargs.get('pk'),
+                                                 activity_type=ActivityTypes.OPENED) \
+                                         .values('subscriber__id', 'subscriber__email') \
+                                         .annotate(total_opens=Count('id')) \
+                                         .order_by('-total_opens')[:10]
 
         location_open_activities = Activity.objects \
-            .filter(email__campaign_id=self.kwargs.get('pk'), activity_type=ActivityTypes.OPENED) \
-            .values('location__country__code', 'location__country__name') \
-            .annotate(total_opens=Count('id')) \
-            .order_by('-total_opens')[:10]
+                                       .filter(email__campaign_id=self.kwargs.get('pk'),
+                                               activity_type=ActivityTypes.OPENED) \
+                                       .values('location__country__code', 'location__country__name') \
+                                       .annotate(total_opens=Count('id')) \
+                                       .order_by('-total_opens')[:10]
 
         kwargs.update({
             'links': links,
@@ -416,10 +418,12 @@ def campaign_edit_content(request, pk):
 @login_required
 def campaign_test_email(request, pk):
     campaign = get_object_or_404(Campaign, pk=pk)
+    connection = get_campaign_connection(campaign=campaign)
+
     if request.method == 'POST':
         form = CampaignTestEmailForm(request.POST)
         if form.is_valid():
-            form.send(campaign.email)
+            form.send(campaign.email, connection=connection)
             return redirect(campaign.get_absolute_url())
     else:
         form = CampaignTestEmailForm()


### PR DESCRIPTION
- Database is built in a view to use multiple email clients.
- But, on the Backend default connection is used which only uses the email client available in the env or settings
- Added the `get_campaign_connection` function which uses the db object to accept the email client details, default is still env or settings